### PR TITLE
emptying reflectionCountByDate each time the function is called

### DIFF
--- a/server/modules/convertCount.js
+++ b/server/modules/convertCount.js
@@ -1,5 +1,5 @@
-var reflectionCountByDate = [];
 var convertCount = function(countData){
+  var reflectionCountByDate = [];
   for (i=0; i<countData.length; i++){
     var countByDate = {
       date: '',

--- a/server/routes/reflection.js
+++ b/server/routes/reflection.js
@@ -33,8 +33,6 @@ router.get('/', function (req, res) {
 });
 
 router.get('/countByDay', function(req, res){
-  console.log('count by day hit');
-
   Reflection.aggregate(
     [{$group: {
       _id : { month: {$month : '$reflectionDate'}, day: {$dayOfMonth: '$reflectionDate'}, year: { $year : '$reflectionDate'}},
@@ -44,6 +42,7 @@ router.get('/countByDay', function(req, res){
     if (err){
       console.log('error in count by day: ', err);
     }
+    console.log('count data: ', countData);
     var reflectionCountByDate = convertCount(countData);
     res.send(reflectionCountByDate);
   });


### PR DESCRIPTION
Moved the array definition into the function so that it empties out when called. This takes care of duplicate date entries when the admin page is reloaded.